### PR TITLE
TC_12_48_01_02 | User can copy API key created by CreateAPI button in Table

### DIFF
--- a/new_pom/components/tableComponent.js
+++ b/new_pom/components/tableComponent.js
@@ -7,6 +7,7 @@ export default class TableComponent {
         this.documentStatus = this.page.locator('.documents__documentStatus').first();
         this.optionsBtn = this.page.getByText('Options');
         this.editAndResendBtn = this.page.getByText('Edit & Resend');
+        this.createAPIKeyBtn = this.page.locator('.documents__empty-table').getByRole('button', {name: 'Create API key'});
     }
 
     async clickOptionsBtn() {
@@ -18,4 +19,8 @@ export default class TableComponent {
         await this.editAndResendBtn.click();
     }
 
+    async clickCreateAPIKeyBtnInTable() {
+        await this.createAPIKeyBtn.waitFor();
+        await this.createAPIKeyBtn.click();
+    }
 }

--- a/new_pom/modalWindows/createAPIKeyModal.js
+++ b/new_pom/modalWindows/createAPIKeyModal.js
@@ -14,11 +14,11 @@ export default class NewCreateAPIKeyModal {
         await this.createAPIKeyNameInput.fill(keyName);
     }
 
-    async clickCreateAPIButton() {
+    async clickCreateAPIBtn() {
         await this.createAPIButton.click();
     }
 
-    async clickCopyAPIButton() {
+    async clickCopyAPIBtn() {
         await this.copyAPIButton.click();
     }
 
@@ -27,7 +27,7 @@ export default class NewCreateAPIKeyModal {
         return await this.APIKeyValue.textContent();
     }
 
-    async clickCloseAPIModalButton() {
+    async clickCloseAPIModalBtn() {
         await this.closeAPIModalButton.click();
     }
 }

--- a/new_pom/modalWindows/createAPIKeyModal.js
+++ b/new_pom/modalWindows/createAPIKeyModal.js
@@ -2,16 +2,16 @@ export default class NewCreateAPIKeyModal {
     constructor(page) {
         this.page = page;
 
-        this.createAPIKeyNameInput = this.page.getByPlaceholder('API key name');
+        this.createAPIKeyNameField = this.page.getByPlaceholder('API key name');
         this.createAPIButton = this.page.getByRole('button', { name: 'Create API' });
-        this.copyAPIButton = this.page.getByRole('button', { name: 'Copy API' });
+        this.copyAPIBtn = this.page.getByRole('button', { name: 'Copy API' });
         this.APIKeyValue = this.page.locator('.apiKeyModal__value');
-        this.closeAPIModalButton = this.page.locator('.modal__close-button > div > .injected-svg > path');
+        this.closeAPIModalBtn = this.page.locator('.modal__close-button > div > .injected-svg > path');
     }
 
-    async fillCreateAPIKeyNameInput(keyName) {
-        await this.createAPIKeyNameInput.waitFor();
-        await this.createAPIKeyNameInput.fill(keyName);
+    async fillCreateAPIKeyNameField(keyName) {
+        await this.createAPIKeyNameField.waitFor();
+        await this.createAPIKeyNameField.fill(keyName);
     }
 
     async clickCreateAPIBtn() {
@@ -19,7 +19,7 @@ export default class NewCreateAPIKeyModal {
     }
 
     async clickCopyAPIBtn() {
-        await this.copyAPIButton.click();
+        await this.copyAPIBtn.click();
     }
 
     async getAPIKeyValueText() {
@@ -28,6 +28,6 @@ export default class NewCreateAPIKeyModal {
     }
 
     async clickCloseAPIModalBtn() {
-        await this.closeAPIModalButton.click();
+        await this.closeAPIModalBtn.click();
     }
 }

--- a/new_pom/modalWindows/createAPIKeyModal.js
+++ b/new_pom/modalWindows/createAPIKeyModal.js
@@ -9,7 +9,7 @@ export default class NewCreateAPIKeyModal {
         this.closeAPIModalButton = this.page.locator('.modal__close-button > div > .injected-svg > path');
     }
 
-    async fillInCreateAPIKeyNameInput(keyName) {
+    async fillCreateAPIKeyNameInput(keyName) {
         await this.createAPIKeyNameInput.waitFor();
         await this.createAPIKeyNameInput.fill(keyName);
     }

--- a/new_pom/modalWindows/createAPIKeyModal.js
+++ b/new_pom/modalWindows/createAPIKeyModal.js
@@ -2,16 +2,16 @@ export default class NewCreateAPIKeyModal {
     constructor(page) {
         this.page = page;
 
-        this.createAPIKeyNameField = this.page.getByPlaceholder('API key name');
+        this.createAPIKeyNameInput = this.page.getByPlaceholder('API key name');
         this.createAPIButton = this.page.getByRole('button', { name: 'Create API' });
         this.copyAPIButton = this.page.getByRole('button', { name: 'Copy API' });
         this.APIKeyValue = this.page.locator('.apiKeyModal__value');
         this.closeAPIModalButton = this.page.locator('.modal__close-button > div > .injected-svg > path');
     }
 
-    async fillInCreateAPIKeyNameField(keyName) {
-        await this.createAPIKeyNameField.waitFor();
-        await this.createAPIKeyNameField.fill(keyName);
+    async fillInCreateAPIKeyNameInput(keyName) {
+        await this.createAPIKeyNameInput.waitFor();
+        await this.createAPIKeyNameInput.fill(keyName);
     }
 
     async clickCreateAPIButton() {

--- a/new_pom/modalWindows/createAPIKeyModal.js
+++ b/new_pom/modalWindows/createAPIKeyModal.js
@@ -3,7 +3,7 @@ export default class NewCreateAPIKeyModal {
         this.page = page;
 
         this.createAPIKeyNameField = this.page.getByPlaceholder('API key name');
-        this.createAPIButton = this.page.getByRole('button', { name: 'Create API' });
+        this.createAPIBtn = this.page.getByRole('button', { name: 'Create API' });
         this.copyAPIBtn = this.page.getByRole('button', { name: 'Copy API' });
         this.APIKeyValue = this.page.locator('.apiKeyModal__value');
         this.closeAPIModalBtn = this.page.locator('.modal__close-button > div > .injected-svg > path');
@@ -15,7 +15,7 @@ export default class NewCreateAPIKeyModal {
     }
 
     async clickCreateAPIBtn() {
-        await this.createAPIButton.click();
+        await this.createAPIBtn.click();
     }
 
     async clickCopyAPIBtn() {

--- a/new_pom/pages/settings/settingsAPIPage.js
+++ b/new_pom/pages/settings/settingsAPIPage.js
@@ -1,24 +1,25 @@
 import ToastComponent from "../../components/toastComponent";
+import TableComponent from "../../components/tableComponent";
 
 export default class NewSettingsAPIPage {
     constructor(page) {
         this.page = page;
 
         this.toast = new ToastComponent(this.page);
+        this.table = new TableComponent(this.page)
 
-        this.createAPIKeyButtonAtRight = this.page.locator('.team__header-container').getByRole('button', {name: 'Create API key'});
+        this.createAPIKeyBtnAtRight = this.page.locator('.team__header-container').getByRole('button', {name: 'Create API key'});
         this.billingDetailsField = this.page.getByPlaceholder('Enter billing details here');
         this.billingDetailsTextField = this.page.locator('.billing__details > form textarea');
     }
 
     async clickCreateAPIKeyButtonAtRight() {
-        await this.createAPIKeyButtonAtRight.waitFor();
-        await this.createAPIKeyButtonAtRight.click();
+        await this.createAPIKeyBtnAtRight.waitFor();
+        await this.createAPIKeyBtnAtRight.click();
     }
 
     async fillBillingDetailsField(text) {
         await this.billingDetailsField.waitFor();
         await this.billingDetailsField.fill(text);
     }
-
 }

--- a/new_pom/pages/settings/settingsAPIPage.js
+++ b/new_pom/pages/settings/settingsAPIPage.js
@@ -13,7 +13,7 @@ export default class NewSettingsAPIPage {
         this.billingDetailsTextField = this.page.locator('.billing__details > form textarea');
     }
 
-    async clickCreateAPIKeyButtonAtRight() {
+    async clickCreateAPIKeyBtnAtRight() {
         await this.createAPIKeyBtnAtRight.waitFor();
         await this.createAPIKeyBtnAtRight.click();
     }

--- a/tests/12CreateAPIkey.spec.js
+++ b/tests/12CreateAPIkey.spec.js
@@ -10,7 +10,7 @@ test.describe('Create API key', () => {
         await signPage.sideMenu.clickSettings();
         await settingsCompanyPage.horizontalMenu.clickAPI();
 
-        await settingsAPIPage.clickCreateAPIKeyButtonAtRight();
+        await settingsAPIPage.clickCreateAPIKeyBtnAtRight();
 
         await createAPIKeyModal.fillCreateAPIKeyNameField(API_KEY_NAME);
         await createAPIKeyModal.clickCreateAPIBtn();

--- a/tests/12CreateAPIkey.spec.js
+++ b/tests/12CreateAPIkey.spec.js
@@ -12,7 +12,7 @@ test.describe('Create API key', () => {
 
         await settingsAPIPage.clickCreateAPIKeyButtonAtRight();
 
-        await createAPIKeyModal.fillCreateAPIKeyNameInput(API_KEY_NAME);
+        await createAPIKeyModal.fillCreateAPIKeyNameField(API_KEY_NAME);
         await createAPIKeyModal.clickCreateAPIBtn();
         await createAPIKeyModal.clickCopyAPIBtn();
 
@@ -32,7 +32,7 @@ test.describe('Create API key', () => {
 
         await settingsAPIPage.table.clickCreateAPIKeyBtnInTable();
 
-        await createAPIKeyModal.fillCreateAPIKeyNameInput(API_KEY_NAME);
+        await createAPIKeyModal.fillCreateAPIKeyNameField(API_KEY_NAME);
         await createAPIKeyModal.clickCreateAPIBtn();
         await createAPIKeyModal.clickCopyAPIBtn();
 

--- a/tests/12CreateAPIkey.spec.js
+++ b/tests/12CreateAPIkey.spec.js
@@ -12,7 +12,27 @@ test.describe('Create API key', () => {
 
         await settingsAPIPage.clickCreateAPIKeyButtonAtRight();
 
-        await createAPIKeyModal.fillInCreateAPIKeyNameField(API_KEY_NAME);
+        await createAPIKeyModal.fillInCreateAPIKeyNameInput(API_KEY_NAME);
+        await createAPIKeyModal.clickCreateAPIButton();
+        await createAPIKeyModal.clickCopyAPIButton();
+
+        await settingsAPIPage.toast.toastBody.waitFor();
+
+        const clipboardApiKeyValue = await createAPIKeyModal.getAPIKeyValueText();
+
+        await createAPIKeyModal.clickCloseAPIModalButton();
+        await settingsAPIPage.fillBillingDetailsField(clipboardApiKeyValue);
+
+        await expect(settingsAPIPage.billingDetailsTextField).toHaveText(clipboardApiKeyValue);
+    });
+
+    test('TC_12_48_01_02 | Verify User can copy API key created by the "Create API" button in Table.', async ({ createBusinessUserAndLogin, signPage, settingsCompanyPage, settingsAPIPage, createAPIKeyModal}) => {
+        await signPage.sideMenu.clickSettings();
+        await settingsCompanyPage.horizontalMenu.clickAPI();
+
+        await settingsAPIPage.table.clickCreateAPIKeyBtnInTable();
+
+        await createAPIKeyModal.fillInCreateAPIKeyNameInput(API_KEY_NAME);
         await createAPIKeyModal.clickCreateAPIButton();
         await createAPIKeyModal.clickCopyAPIButton();
 

--- a/tests/12CreateAPIkey.spec.js
+++ b/tests/12CreateAPIkey.spec.js
@@ -12,7 +12,7 @@ test.describe('Create API key', () => {
 
         await settingsAPIPage.clickCreateAPIKeyButtonAtRight();
 
-        await createAPIKeyModal.fillInCreateAPIKeyNameInput(API_KEY_NAME);
+        await createAPIKeyModal.fillCreateAPIKeyNameInput(API_KEY_NAME);
         await createAPIKeyModal.clickCreateAPIButton();
         await createAPIKeyModal.clickCopyAPIButton();
 
@@ -32,7 +32,7 @@ test.describe('Create API key', () => {
 
         await settingsAPIPage.table.clickCreateAPIKeyBtnInTable();
 
-        await createAPIKeyModal.fillInCreateAPIKeyNameInput(API_KEY_NAME);
+        await createAPIKeyModal.fillCreateAPIKeyNameInput(API_KEY_NAME);
         await createAPIKeyModal.clickCreateAPIButton();
         await createAPIKeyModal.clickCopyAPIButton();
 

--- a/tests/12CreateAPIkey.spec.js
+++ b/tests/12CreateAPIkey.spec.js
@@ -13,14 +13,14 @@ test.describe('Create API key', () => {
         await settingsAPIPage.clickCreateAPIKeyButtonAtRight();
 
         await createAPIKeyModal.fillCreateAPIKeyNameInput(API_KEY_NAME);
-        await createAPIKeyModal.clickCreateAPIButton();
-        await createAPIKeyModal.clickCopyAPIButton();
+        await createAPIKeyModal.clickCreateAPIBtn();
+        await createAPIKeyModal.clickCopyAPIBtn();
 
         await settingsAPIPage.toast.toastBody.waitFor();
 
         const clipboardApiKeyValue = await createAPIKeyModal.getAPIKeyValueText();
 
-        await createAPIKeyModal.clickCloseAPIModalButton();
+        await createAPIKeyModal.clickCloseAPIModalBtn();
         await settingsAPIPage.fillBillingDetailsField(clipboardApiKeyValue);
 
         await expect(settingsAPIPage.billingDetailsTextField).toHaveText(clipboardApiKeyValue);
@@ -33,14 +33,14 @@ test.describe('Create API key', () => {
         await settingsAPIPage.table.clickCreateAPIKeyBtnInTable();
 
         await createAPIKeyModal.fillCreateAPIKeyNameInput(API_KEY_NAME);
-        await createAPIKeyModal.clickCreateAPIButton();
-        await createAPIKeyModal.clickCopyAPIButton();
+        await createAPIKeyModal.clickCreateAPIBtn();
+        await createAPIKeyModal.clickCopyAPIBtn();
 
         await settingsAPIPage.toast.toastBody.waitFor();
 
         const clipboardApiKeyValue = await createAPIKeyModal.getAPIKeyValueText();
 
-        await createAPIKeyModal.clickCloseAPIModalButton();
+        await createAPIKeyModal.clickCloseAPIModalBtn();
         await settingsAPIPage.fillBillingDetailsField(clipboardApiKeyValue);
 
         await expect(settingsAPIPage.billingDetailsTextField).toHaveText(clipboardApiKeyValue);


### PR DESCRIPTION
- test TC_12_48_01_02 added
- tableComponent updated with clickCreateAPIKeyBtnInTable method and imported to settingsAPIPage
- Button renamed to Btn following the naming convention 